### PR TITLE
Removal of master and slave language

### DIFF
--- a/One_time_scripts/evaluate_review_conclusions.py
+++ b/One_time_scripts/evaluate_review_conclusions.py
@@ -62,7 +62,7 @@ def evaluate_fraud_review_conclusions(decisional_entity, start_period, end_perio
     risk_conn = postgres_utils.get_db_connection_from_config(
         load_config.load_config(config_file, config_name='risk-write'))
     sun_conn = postgres_utils.get_db_connection_from_config(
-        load_config.load_config(config_file, 'risk-cloud-slave'))
+        load_config.load_config(config_file, 'risk-cloud-subordinate'))
 
     if start_period > end_period:
         raise Exception('The start_period must not exceed end_period.')

--- a/One_time_scripts/extract_org_missing_from_the_task_list/extract_pos_reviewed_org_missing_from_task_list.py
+++ b/One_time_scripts/extract_org_missing_from_the_task_list/extract_pos_reviewed_org_missing_from_task_list.py
@@ -60,7 +60,7 @@ def main():
 
     config_file = "db-config.yaml"
     risk_conn = load_db_conn_from_config_file(config_file, 'risk-write')
-    sun_conn = load_db_conn_from_config_file(config_file, 'risk-cloud-slave')
+    sun_conn = load_db_conn_from_config_file(config_file, 'risk-cloud-subordinate')
 
     start_time = '2015-06-01'
     end_time = '2015-07-01'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.